### PR TITLE
Optional action descriptions

### DIFF
--- a/src/actionLoading.ts
+++ b/src/actionLoading.ts
@@ -47,6 +47,7 @@ export const loadAllActions = (actionDir: string, envConfig: any): Action[] => {
             loadedActions.push(
                 new RestAction(
                     nameFromYamlConfig(file),
+                    null,
                     actionDef,
                     host + actionDef.endpoint,
                     actionDef.service,
@@ -54,12 +55,13 @@ export const loadAllActions = (actionDir: string, envConfig: any): Action[] => {
             );
         } else if (isTimerAction(actionDef)) {
             loadedActions.push(
-                new TimerAction(nameFromYamlConfig(file), actionDef),
+                new TimerAction(nameFromYamlConfig(file), null, actionDef),
             );
         } else if (isWebsocketAction(actionDef)) {
             loadedActions.push(
                 new WebSocketAction(
                     nameFromYamlConfig(file),
+                    null,
                     actionDef,
                     actionDef.service,
                     `wss://${envConfig[actionDef.service]}${
@@ -69,11 +71,15 @@ export const loadAllActions = (actionDir: string, envConfig: any): Action[] => {
             );
         } else if (isMqttAction(actionDef)) {
             loadedActions.push(
-                new MqttAction(nameFromYamlConfig(file), actionDef),
+                new MqttAction(nameFromYamlConfig(file), null, actionDef),
             );
         } else if (isMqttPublishAction(actionDef)) {
             loadedActions.push(
-                new MqttPublishAction(nameFromYamlConfig(file), actionDef),
+                new MqttPublishAction(
+                    nameFromYamlConfig(file),
+                    null,
+                    actionDef,
+                ),
             );
         } else {
             getLogger('unknown').error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ async function invokeActionsSynchronously(scenario: Scenario) {
                 const scenarioResults = RESULTS.get(scenarioName);
                 if (scenarioResults)
                     scenarioResults.push(
-                        new TestResult(action.name, duration, true),
+                        new TestResult(action.description, duration, true),
                     );
 
                 if (result)

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ async function invokeActionsSynchronously(scenario: Scenario) {
         Object.assign(ctx, { action: action.name });
 
         getLogger(scenarioName).info(
-            pad(`#### (A): ${action.name} `, MSG_WIDTH, '#'),
+            pad(`#### (A): ${action.description} `, MSG_WIDTH, '#'),
             ctx,
         );
         const start = process.hrtime();
@@ -134,7 +134,7 @@ async function invokeActionsSynchronously(scenario: Scenario) {
                 const scenarioResults = RESULTS.get(scenarioName);
                 if (scenarioResults)
                     scenarioResults.push(
-                        new TestResult(action.name, duration, false),
+                        new TestResult(action.description, duration, false),
                     );
 
                 if (reason)
@@ -160,7 +160,7 @@ async function invokeActionsSynchronously(scenario: Scenario) {
 function printResults(): any {
     RESULTS.forEach((result, scenario) => {
         const ctx = { scenario };
-        const MSG_WIDTH = 60;
+        const MSG_WIDTH = 100;
 
         getLogger(scenario).info(
             pad(`#### SUMMARY: ${scenario} `, MSG_WIDTH, '#'),
@@ -170,12 +170,12 @@ function printResults(): any {
         result.forEach((res: TestResult) => {
             if (res.successful)
                 getLogger(scenario).info(
-                    ` OK: ${pad(res.action, 30)} ${res.duration} ms`,
+                    ` OK: ${pad(res.action, 50)} ${res.duration} ms`,
                     ctx,
                 );
             else
                 getLogger(scenario).info(
-                    `NOK: ${pad(res.action, 30)} ${res.duration} ms`,
+                    `NOK: ${pad(res.action, 50)} ${res.duration} ms`,
                     ctx,
                 );
         });

--- a/src/model/Action.ts
+++ b/src/model/Action.ts
@@ -4,7 +4,7 @@ import { ActionCallback } from './ActionCallback';
 
 interface Action {
     name: string;
-    description: string | null;
+    description: string;
     type: ActionType;
     invoke(scenario: Scenario): ActionCallback;
 }

--- a/src/model/Action.ts
+++ b/src/model/Action.ts
@@ -4,6 +4,7 @@ import { ActionCallback } from './ActionCallback';
 
 interface Action {
     name: string;
+    description: string;
     type: ActionType;
     invoke(scenario: Scenario): ActionCallback;
 }

--- a/src/model/Action.ts
+++ b/src/model/Action.ts
@@ -4,7 +4,7 @@ import { ActionCallback } from './ActionCallback';
 
 interface Action {
     name: string;
-    description: string;
+    description: string | null;
     type: ActionType;
     invoke(scenario: Scenario): ActionCallback;
 }

--- a/src/model/MqttAction.ts
+++ b/src/model/MqttAction.ts
@@ -11,6 +11,8 @@ import { Scenario } from './Scenario';
 class MqttAction implements Action {
     name: string;
 
+    description: string;
+
     type = ActionType.MQTT;
 
     url: string;
@@ -48,6 +50,7 @@ class MqttAction implements Action {
         protoClass = mqttDefinition.protoClass,
     ) {
         this.name = name;
+        this.description = name;
         this.url = url;
         this.username = username;
         this.password = password;

--- a/src/model/MqttAction.ts
+++ b/src/model/MqttAction.ts
@@ -37,6 +37,7 @@ class MqttAction implements Action {
 
     constructor(
         name: string,
+        desc = name,
         mqttDefinition: any,
         url = mqttDefinition.url,
         username = mqttDefinition.username,
@@ -50,7 +51,6 @@ class MqttAction implements Action {
         protoClass = mqttDefinition.protoClass,
     ) {
         this.name = name;
-        this.description = name;
         this.url = url;
         this.username = username;
         this.password = password;
@@ -61,11 +61,13 @@ class MqttAction implements Action {
         this.messageFilter = messageFilter;
         this.protoFile = protoFile;
         this.protoClass = protoClass;
+        this.description = desc;
     }
 
     static fromTemplate(mqttDefinition: any, template: MqttAction): MqttAction {
         return new MqttAction(
             template.name,
+            mqttDefinition.description || mqttDefinition.name,
             Object.assign(Object.assign({}, template), mqttDefinition),
         );
     }

--- a/src/model/MqttPublishAction.ts
+++ b/src/model/MqttPublishAction.ts
@@ -15,6 +15,8 @@ import { Scenario } from './Scenario';
 class MqttPublishAction implements Action {
     name: string;
 
+    description: string;
+
     type = ActionType.MQTT_PUBLISH;
 
     url: string;
@@ -43,6 +45,7 @@ class MqttPublishAction implements Action {
         protoClass = mqttDefinition.protoClass,
     ) {
         this.name = name;
+        this.description = name;
         this.url = url;
         this.username = username;
         this.password = password;

--- a/src/model/MqttPublishAction.ts
+++ b/src/model/MqttPublishAction.ts
@@ -35,6 +35,7 @@ class MqttPublishAction implements Action {
 
     constructor(
         name: string,
+        desc = name,
         mqttDefinition: any,
         url = mqttDefinition.url,
         username = mqttDefinition.username,
@@ -45,7 +46,6 @@ class MqttPublishAction implements Action {
         protoClass = mqttDefinition.protoClass,
     ) {
         this.name = name;
-        this.description = name;
         this.url = url;
         this.username = username;
         this.password = password;
@@ -53,6 +53,7 @@ class MqttPublishAction implements Action {
         this.data = data;
         this.protoFile = protoFile;
         this.protoClass = protoClass;
+        this.description = desc;
     }
 
     static fromTemplate(
@@ -61,6 +62,7 @@ class MqttPublishAction implements Action {
     ): MqttPublishAction {
         return new MqttPublishAction(
             template.name,
+            mqttDefinition.description || mqttDefinition.name,
             Object.assign(Object.assign({}, template), mqttDefinition),
         );
     }

--- a/src/model/RestAction.ts
+++ b/src/model/RestAction.ts
@@ -20,6 +20,8 @@ class RestAction implements Action {
 
     name: string;
 
+    description: string;
+
     type = ActionType.REST;
 
     url: string;
@@ -52,6 +54,7 @@ class RestAction implements Action {
         vars = actionDef.variables,
     ) {
         this.name = name;
+        this.description = name;
         this.url = url;
         this.serviceName = serviceName;
         this.method = restMethod;

--- a/src/model/RestAction.ts
+++ b/src/model/RestAction.ts
@@ -52,9 +52,10 @@ class RestAction implements Action {
         restForm = actionDef.form,
         validators = actionDef.responseValidation,
         vars = actionDef.variables,
+        desc = name,
     ) {
         this.name = name;
-        this.description = name;
+        this.description = desc;
         this.url = url;
         this.serviceName = serviceName;
         this.method = restMethod;
@@ -95,6 +96,7 @@ class RestAction implements Action {
             template.variables
                 ? Object.assign(template.variables, actionDef.variables)
                 : actionDef.variables,
+            actionDef.description || actionDef.name,
         );
     }
 

--- a/src/model/RestAction.ts
+++ b/src/model/RestAction.ts
@@ -42,6 +42,7 @@ class RestAction implements Action {
 
     constructor(
         name: string,
+        desc = name,
         actionDef: any,
         url: string,
         serviceName: string,
@@ -52,7 +53,6 @@ class RestAction implements Action {
         restForm = actionDef.form,
         validators = actionDef.responseValidation,
         vars = actionDef.variables,
-        desc = name,
     ) {
         this.name = name;
         this.description = desc;
@@ -70,6 +70,7 @@ class RestAction implements Action {
     static fromTemplate(actionDef: any, template: RestAction): RestAction {
         return new RestAction(
             actionDef.name,
+            actionDef.description || actionDef.name,
             actionDef,
             template.url,
             template.serviceName,
@@ -96,7 +97,6 @@ class RestAction implements Action {
             template.variables
                 ? Object.assign(template.variables, actionDef.variables)
                 : actionDef.variables,
-            actionDef.description || actionDef.name,
         );
     }
 

--- a/src/model/TimerAction.ts
+++ b/src/model/TimerAction.ts
@@ -8,6 +8,8 @@ import { addDelay } from '../diagramDrawing';
 class TimerAction implements Action {
     name: string;
 
+    description: string;
+
     type = ActionType.TIMER;
 
     duration: number;
@@ -18,6 +20,7 @@ class TimerAction implements Action {
         duration = timerDefinition.durationInSec,
     ) {
         this.name = name;
+        this.description = name;
         this.duration = duration;
     }
 

--- a/src/model/TimerAction.ts
+++ b/src/model/TimerAction.ts
@@ -16,12 +16,13 @@ class TimerAction implements Action {
 
     constructor(
         name: string,
+        desc = name,
         timerDefinition: any,
         duration = timerDefinition.durationInSec,
     ) {
         this.name = name;
-        this.description = name;
         this.duration = duration;
+        this.description = desc;
     }
 
     static fromTemplate(
@@ -30,6 +31,7 @@ class TimerAction implements Action {
     ): TimerAction {
         return new TimerAction(
             template.name,
+            timerDefinition.description || timerDefinition.name,
             timerDefinition,
             timerDefinition.durationInSec || template.duration,
         );

--- a/src/model/WebSocketAction.ts
+++ b/src/model/WebSocketAction.ts
@@ -22,6 +22,8 @@ class WebSocketAction implements Action {
 
     name: string;
 
+    description: string;
+
     type = ActionType.WEBSOCKET;
 
     url: string;
@@ -47,6 +49,7 @@ class WebSocketAction implements Action {
         messageFilter = wsDefinition.messageFilter,
     ) {
         this.name = name;
+        this.description = name;
         this.serviceName = serviceName;
         this.url = url;
         this.headers = headers;

--- a/src/model/WebSocketAction.ts
+++ b/src/model/WebSocketAction.ts
@@ -40,6 +40,7 @@ class WebSocketAction implements Action {
 
     constructor(
         name: string,
+        desc = name,
         wsDefinition: any,
         serviceName: string,
         url = wsDefinition.url,
@@ -49,13 +50,13 @@ class WebSocketAction implements Action {
         messageFilter = wsDefinition.messageFilter,
     ) {
         this.name = name;
-        this.description = name;
         this.serviceName = serviceName;
         this.url = url;
         this.headers = headers;
         this.data = data;
         this.expectedNumberOfMessages = expectedNumberOfMessages;
         this.messageFilter = messageFilter;
+        this.description = desc;
 
         this.receivedMessages = new Set<string>();
     }
@@ -66,6 +67,7 @@ class WebSocketAction implements Action {
     ): WebSocketAction {
         return new WebSocketAction(
             template.name,
+            wsDefinition.description || wsDefinition.name,
             wsDefinition,
             template.serviceName,
             template.url,

--- a/src/tests/actionLoading.spec.ts
+++ b/src/tests/actionLoading.spec.ts
@@ -15,6 +15,7 @@ describe('Action loading', () => {
         );
         expect(result).to.have.lengthOf(1);
         expect(result[0].name).to.be.equal('restAction');
+        expect(result[0].description).to.be.equal('restAction');
         expect(result[0].type).to.be.equal(ActionType.REST);
         expect(result[0]).to.have.property('url');
         expect(result[0]).to.have.property('method');

--- a/src/tests/actionLoading.spec.ts
+++ b/src/tests/actionLoading.spec.ts
@@ -15,7 +15,7 @@ describe('Action loading', () => {
         );
         expect(result).to.have.lengthOf(1);
         expect(result[0].name).to.be.equal('restAction');
-        expect(result[0].description).to.be.equal('restAction');
+        expect(result[0].description).to.be.null;
         expect(result[0].type).to.be.equal(ActionType.REST);
         expect(result[0]).to.have.property('url');
         expect(result[0]).to.have.property('method');

--- a/src/tests/resources/scenarios/s1-testScenario.yaml
+++ b/src/tests/resources/scenarios/s1-testScenario.yaml
@@ -1,6 +1,7 @@
 description: "test description"
 actions:
   - name: do-something
+    description: "test something"
     method: POST
     data:
       userId: 22

--- a/src/tests/scenarioLoading.spec.ts
+++ b/src/tests/scenarioLoading.spec.ts
@@ -107,4 +107,20 @@ describe('Scenario loading', () => {
             (<RestAction>result[0].actions[0]).responseValidation,
         ).to.contain('userId !== null');
     });
+
+    it('should be able to set action´s description correctly', () => {
+        const testActionCatalog = [
+            {
+                name: 'do-something',
+                type: ActionType.REST,
+                invoke: null,
+                method: 'GET',
+            },
+        ];
+        const result = loadAllScenarios(TEST_SCENARIO_PATH, testActionCatalog);
+        expect(result[0].actions).to.have.lengthOf(1);
+        expect((<RestAction>result[0].actions[0]).description).to.be.equal(
+            'test something',
+        );
+    });
 });

--- a/src/tests/scenarioLoading.spec.ts
+++ b/src/tests/scenarioLoading.spec.ts
@@ -47,7 +47,12 @@ describe('Scenario loading', () => {
 
     it('should be able to parse scenario actions', () => {
         const testActionCatalog = [
-            { name: 'do-something', type: ActionType.REST, invoke: null },
+            {
+                name: 'do-something',
+                description: null,
+                type: ActionType.REST,
+                invoke: null,
+            },
         ];
         const result = loadAllScenarios(TEST_SCENARIO_PATH, testActionCatalog);
         expect(result[0].actions).to.have.lengthOf(1);
@@ -58,6 +63,7 @@ describe('Scenario loading', () => {
         const testActionCatalog = [
             {
                 name: 'do-something',
+                description: null,
                 type: ActionType.REST,
                 invoke: null,
                 method: 'GET',
@@ -72,6 +78,7 @@ describe('Scenario loading', () => {
         const testActionCatalog = [
             {
                 name: 'do-something',
+                description: null,
                 type: ActionType.REST,
                 invoke: null,
                 data: {
@@ -90,6 +97,7 @@ describe('Scenario loading', () => {
         const testActionCatalog = [
             {
                 name: 'do-something',
+                description: null,
                 type: ActionType.REST,
                 invoke: null,
                 responseValidation: ['userId !== null'],
@@ -112,6 +120,7 @@ describe('Scenario loading', () => {
         const testActionCatalog = [
             {
                 name: 'do-something',
+                description: null,
                 type: ActionType.REST,
                 invoke: null,
                 method: 'GET',


### PR DESCRIPTION
since reloading actions is a common feature in ALT scenarios, one cannot see directly from the log what's happening. This feature enables defining custom descriptions for actions in a scenario to provide more context when reading the terminal-log:

...
actions:
  - name: update-user
    description: "changing address of the user"
    ...

