### PR TITLE
adjust logging format

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,16 +1,28 @@
 import * as pad from 'pad';
-import { createLogger, format, transports, Logger } from 'winston';
+import { Logger, createLogger, format, transports } from 'winston';
 import { OUTPUT_DIR } from '.';
 
 const { combine, timestamp, printf } = format;
 
+const trim = (text: string, length: number): string =>
+    text.length > length ? `${text.substring(0, length - 1)}…` : text;
+
+const trimAndPadLeft = (text: string, length: number): string =>
+    pad(trim(text, length), length);
+
+const trimAndPadRight = (text: string, length: number): string =>
+    pad(length, trim(text, length));
+
 const myFormat = printf(
-    info =>
-        `${info.timestamp} [${pad(info.scenario || 'unknown', 30)}] [${pad(
-            info.action || 'unknown',
-            30,
-        )}] ${pad(`[${info.level.toUpperCase()}]`, 7)} #${
-            info.message.startsWith('#') ? info.message : ` ${info.message}`
+    (info): string =>
+        `${info.timestamp} | ${trimAndPadLeft(
+            info.scenario || 'no scenario',
+            15,
+        )} | ${trimAndPadLeft(
+            info.action || 'no action',
+            15,
+        )} | ${trimAndPadRight(`${info.level.toUpperCase()}`, 5)} | ${
+            info.message
         }`,
 );
 

--- a/src/model/Scenario.ts
+++ b/src/model/Scenario.ts
@@ -81,7 +81,7 @@ class Scenario {
                 }
             } else {
                 getLogger(this.name).error(
-                    `ERROR: Could not find any Action definition for: ${actionDef.name}`,
+                    `Could not find any Action definition for: ${actionDef.name}`,
                     { scenario: this.name },
                 );
             }


### PR DESCRIPTION
This adjusts the logging format to be better readable by humans.

The new logging format looks something like this:
```
2019-07-25T10:05:50.511Z | s2-loadScenari… | no action       | ERROR | Could not find any Action definition for: do-something
```

In particular, the padding size for scenarios / actions is decreased and they are truncated if too long.