### PR TITLE
Fix condition to also work with undefined value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,7 @@ async function invokeActionsSynchronously(scenario: Scenario): Promise<void> {
                 ctx,
             );
 
-            if (action.allowFailure === false) {
+            if (action.allowFailure !== true) {
                 successful = false;
             }
             // process.exit(1);


### PR DESCRIPTION
allowFailure value does not default to "false" but is undefined instead